### PR TITLE
Updated bower instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Most of the bundle usage should be self explanatory; for the `player.html`/`twit
 
 
 ## Installation
-
-See the [installation instructions on nodecg-speedcontrol](https://github.com/speedcontrol/nodecg-speedcontrol#installation) on how to install that bundle, and then (if you installed `nodecg-cli`) run `nodecg install speedcontrol/speedcontrol-simpletext` to install this bundle.
+If you don't have `bower` installed, then `npm install -g bower` and see the [installation instructions on nodecg-speedcontrol](https://github.com/speedcontrol/nodecg-speedcontrol#installation) on how to install that bundle, and then (if you installed `nodecg-cli`) run `nodecg install speedcontrol/speedcontrol-simpletext` to install this bundle.
 
 This bundle has no extra configuration options.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Most of the bundle usage should be self explanatory; for the `player.html`/`twit
 
 
 ## Installation
-If you don't have `bower` installed, then `npm install -g bower` and see the [installation instructions on nodecg-speedcontrol](https://github.com/speedcontrol/nodecg-speedcontrol#installation) on how to install that bundle, and then (if you installed `nodecg-cli`) run `nodecg install speedcontrol/speedcontrol-simpletext` to install this bundle.
+If you don't have `bower` installed, first run `npm install -g bower`. Next, see the [installation instructions on nodecg-speedcontrol](https://github.com/speedcontrol/nodecg-speedcontrol#installation) on how to install that bundle, and then (if you installed `nodecg-cli`) run `nodecg install speedcontrol/speedcontrol-simpletext` to install this bundle.
 
 This bundle has no extra configuration options.


### PR DESCRIPTION
Since I have not installed bower in my pc, and this need to use bower

Or, we get
```
Error: Command failed: bower install --production
'bower' is not recognized as an internal or external command,
operable program or batch file.

    at checkExecSyncError (child_process.js:616:11)
    at Object.execSync (child_process.js:652:15)
    at Object.default_1 [as default] (C:\Users\rikusen\AppData\Roaming\nvm\v14.16.0\node_modules\nodecg-cli\dist\lib\install-bundle-deps.js:50:29)        
    at Command.action (C:\Users\rikusen\AppData\Roaming\nvm\v14.16.0\node_modules\nodecg-cli\dist\commands\install.js:99:34)
    at Command.listener [as _actionHandler] (C:\Users\rikusen\AppData\Roaming\nvm\v14.16.0\node_modules\nodecg-cli\node_modules\commander\index.js:426:31)
    at Command._parseCommand (C:\Users\rikusen\AppData\Roaming\nvm\v14.16.0\node_modules\nodecg-cli\node_modules\commander\index.js:1002:14)
    at Command._dispatchSubcommand (C:\Users\rikusen\AppData\Roaming\nvm\v14.16.0\node_modules\nodecg-cli\node_modules\commander\index.js:953:18)
    at Command._parseCommand (C:\Users\rikusen\AppData\Roaming\nvm\v14.16.0\node_modules\nodecg-cli\node_modules\commander\index.js:970:12)
    at Command.parse (C:\Users\rikusen\AppData\Roaming\nvm\v14.16.0\node_modules\nodecg-cli\node_modules\commander\index.js:801:10)
    at Object.<anonymous> (C:\Users\rikusen\AppData\Roaming\nvm\v14.16.0\node_modules\nodecg-cli\dist\index.js:37:9)
```